### PR TITLE
Call av_register_all, else playback of local files might fail.

### DIFF
--- a/DLGPlayer/codec/DLGPlayerDecoder.m
+++ b/DLGPlayer/codec/DLGPlayerDecoder.m
@@ -71,6 +71,7 @@ static int interruptCallback(void *context) {
     }
     
     // 1. Init
+    av_register_all();
     avformat_network_init();
     
     // 2. Open Input


### PR DESCRIPTION
Without this line, I was not able to play a filed copied through iTunes file sharing.